### PR TITLE
Fix deployment exclude logic

### DIFF
--- a/mcp-unified-agents/deployment/deployment_manager.py
+++ b/mcp-unified-agents/deployment/deployment_manager.py
@@ -78,9 +78,16 @@ class DeploymentManager:
     
     def _should_exclude(self, file_path: str) -> bool:
         """Check if file should be excluded from sync"""
+        path = Path(file_path)
+        # Check simple pattern matches
         for pattern in self.EXCLUDE_PATTERNS:
-            if Path(file_path).match(pattern):
+            if path.match(pattern) or path.match(f"**/{pattern}"):
                 return True
+
+        # Explicitly exclude anything under a .git directory
+        if '.git' in path.parts:
+            return True
+
         return False
     
     def _get_files_to_sync(self) -> List[Tuple[Path, Path]]:


### PR DESCRIPTION
## Summary
- avoid deploying `.git` directories by improving the exclude check

## Testing
- `pytest -c /dev/null` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687a2d9cfb68832a8b441208227339d8